### PR TITLE
set up git submodules with a pretest task

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/highlights.js",
   "scripts": {
     "test": "grunt test",
-    "prepublish": "grunt prepublish"
+    "prepublish": "grunt prepublish",
+    "preinstall": "git submodule init && git submodule update"
   },
   "bin": "bin/highlights",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "grunt test",
     "prepublish": "grunt prepublish",
-    "preinstall": "git submodule init && git submodule update"
+    "pretest": "git submodule update --init --recursive"
   },
   "bin": "bin/highlights",
   "repository": {


### PR DESCRIPTION
It's necessary to setup up the git submodules before tests can be run. This script hook makes it happen automatically.