### PR TITLE
added the method requireGrammarsSync() for loading grammars from npm modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ Outputs:
 </pre>
 ```
 
+### Loading Grammars From Modules
+
+highlights exposes the method `requireGrammarsSync`, for loading grammars from
+npm modules. The usage is as follows:
+
+```bash
+npm install atom-language-clojure
+```
+
+```coffee
+Highlights = require 'highlights'
+highlighter = new Highlights()
+highlighter.requireGrammarsSync
+  modulePath: require.resolve('atom-language-clojure/package.json')
+```
+
 ### Developing
 
 * Clone this repository `git clone https://github.com/atom/highlights`

--- a/package.json
+++ b/package.json
@@ -22,15 +22,16 @@
     "first-mate": "^3.0.0",
     "optimist": "^0.6.1",
     "underscore-plus": "^1.5.1",
-    "fs-plus": "^2.2.6"
+    "fs-plus": "^2.2.6",
+    "season": "^5.1.2"
   },
   "devDependencies": {
-    "jasmine-focused": "^1.0.4",
     "grunt": "^0.4.4",
-    "grunt-contrib-coffee": "^0.10.1",
     "grunt-cli": "^0.1.13",
-    "grunt-shell": "^0.6.4",
     "grunt-coffeelint": "0.0.8",
-    "season": "^5.0.2"
+    "grunt-contrib-coffee": "^0.10.1",
+    "grunt-shell": "^0.6.4",
+    "jasmine-focused": "^1.0.4",
+    "atom-language-clojure": "^0.10.0"
   }
 }

--- a/spec/highlights-spec.coffee
+++ b/spec/highlights-spec.coffee
@@ -33,3 +33,16 @@ describe "Highlights", ->
       highlights = new Highlights()
       html = highlights.highlightSync(fileContents: 'test', filePath: 'test.coffee')
       expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="source coffee"><span>test</span></span></div></pre>'
+
+  describe "requireGrammarsSync", ->
+    it "loads a grammar from an npm module", ->
+      highlights = new Highlights()
+      highlights.requireGrammarsSync(modulePath: require.resolve('atom-language-clojure/package.json'))
+      html = highlights.highlightSync(fileContents: '(def ^:dynamic chunk-size 17)', scopeName: 'source.clojure')
+      expect(html).toContain '<span class="meta expression clojure">'
+
+    it "loads default grammars prior to loading grammar from module", ->
+      highlights = new Highlights()
+      highlights.requireGrammarsSync(modulePath: require.resolve('atom-language-clojure/package.json'))
+      html = highlights.highlightSync(fileContents: 'test', scopeName: 'source.coffee')
+      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="source coffee"><span>test</span></span></div></pre>'

--- a/src/highlights.coffee
+++ b/src/highlights.coffee
@@ -1,6 +1,7 @@
 path = require 'path'
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
+CSON = require 'season'
 {GrammarRegistry} = require 'first-mate'
 
 module.exports =
@@ -29,6 +30,21 @@ class Highlights
       continue if @registry.grammarForScopeName(grammar.scopeName)?
       grammar = @registry.createGrammar(grammarPath, grammar)
       @registry.addGrammar(grammar)
+
+  # Public: allows grammars to be loaded from
+  #   an npm module.
+  #  :modulePath - the path to the module to require.
+  requireGrammarsSync: ({modulePath}={}) ->
+    @loadGrammarsSync()
+
+    packageDir = path.dirname(modulePath)
+    grammarsDir = path.resolve(packageDir, 'grammars')
+
+    return unless fs.isDirectorySync(grammarsDir)
+
+    for file in fs.readdirSync(grammarsDir)
+      if grammarPath = CSON.resolve(path.join(grammarsDir, file))
+        @registry.loadGrammarSync(grammarPath)
 
   # Public: Syntax highlight the given file synchronously.
   #


### PR DESCRIPTION
I've added the method `requireGrammarsSync()`, for loading a grammar into the registry from an npm module. This is super useful when using highlights as a stand-alone library, and allows grammars to be published to npm for just this purpose.

FYI, we recently switched to highlights as our syntax highlighter for npm. awesome work!

![screen shot 2015-01-30 at 12 15 20 am](https://cloud.githubusercontent.com/assets/194609/5972896/d15afada-a815-11e4-97a3-c6f3956424f3.png)
