### PR TITLE
switch to a dependency that is on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "grunt-contrib-coffee": "^0.10.1",
     "grunt-shell": "^0.6.4",
     "jasmine-focused": "^1.0.4",
-    "atom-language-clojure": "^0.10.0"
+    "language-erlang": "^2.0.0"
   }
 }

--- a/spec/highlights-spec.coffee
+++ b/spec/highlights-spec.coffee
@@ -37,16 +37,16 @@ describe "Highlights", ->
   describe "requireGrammarsSync", ->
     it "loads the grammars from a file-based npm module path", ->
       highlights = new Highlights()
-      highlights.requireGrammarsSync(modulePath: require.resolve('atom-language-clojure/package.json'))
-      expect(highlights.registry.grammarForScopeName('source.clojure').path).toBe path.resolve(__dirname, '..', 'node_modules', 'atom-language-clojure', 'grammars', 'clojure.cson')
+      highlights.requireGrammarsSync(modulePath: require.resolve('language-erlang/package.json'))
+      expect(highlights.registry.grammarForScopeName('source.erlang').path).toBe path.resolve(__dirname, '..', 'node_modules', 'language-erlang', 'grammars', 'erlang.cson')
 
     it "loads the grammars from a folder-based npm module path", ->
       highlights = new Highlights()
-      highlights.requireGrammarsSync(modulePath: path.resolve(__dirname, '..', 'node_modules', 'atom-language-clojure'))
-      expect(highlights.registry.grammarForScopeName('source.clojure').path).toBe path.resolve(__dirname, '..', 'node_modules', 'atom-language-clojure', 'grammars', 'clojure.cson')
+      highlights.requireGrammarsSync(modulePath: path.resolve(__dirname, '..', 'node_modules', 'language-erlang'))
+      expect(highlights.registry.grammarForScopeName('source.erlang').path).toBe path.resolve(__dirname, '..', 'node_modules', 'language-erlang', 'grammars', 'erlang.cson')
 
     it "loads default grammars prior to loading grammar from module", ->
       highlights = new Highlights()
-      highlights.requireGrammarsSync(modulePath: require.resolve('atom-language-clojure/package.json'))
+      highlights.requireGrammarsSync(modulePath: require.resolve('language-erlang/package.json'))
       html = highlights.highlightSync(fileContents: 'test', scopeName: 'source.coffee')
       expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="source coffee"><span>test</span></span></div></pre>'


### PR DESCRIPTION
Now that clojure is packaged along with highlights, it's not a great candidate for testing the npm module loading functionality.

It's a bit of a nit, but I've updated the tests to use `language-erlang`, which is only present on npm.