### PR TITLE
bump firstmate version, support 0.12, iojs, 4, and 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,9 @@ node_js:
   - iojs
   - 4
   - 5
+
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq -y g++-4.8
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ notifications:
 
 node_js:
   - 0.10
+  - 0.12
+  - iojs
+  - 4
+  - 5

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/atom/highlights",
   "dependencies": {
-    "first-mate": "^5.0.0",
+    "first-mate": "^5.1.1",
     "first-mate-select-grammar": "^1.0.1",
     "fs-plus": "^2.2.6",
     "once": "^1.3.2",


### PR DESCRIPTION
firstmate was bumped to 5.1.1 to bump oniguruma (that bump moved up to nan 2)
- firstmate 5.1.1: https://github.com/atom/first-mate/commit/ff2537ac1f48bc266264e33c25a237adb2ff42bf
- oniguruma 5.1.2: https://github.com/atom/node-oniguruma/commit/9425e290105cadef46ca857cc8b9682fb7fe8dca

this would help to support iojs, node 4, 5