### PR TITLE
fix: upgrades our dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+<a name="1.4.0"></a>
+# [1.4.0](https://github.com/atom/highlights/compare/v1.3.1...v1.4.0) (2016-07-08)
+
+
+### Bug Fixes
+
+* upgrades our dependencies, and adds standard-version for CHANGELOG/semver management ([e9f40d8](https://github.com/atom/highlights/commit/e9f40d8))
+
+
+### Features
+
+* upgrade language-javascript to v0.119.0 release ([#41](https://github.com/atom/highlights/issues/41)) ([7fa4414](https://github.com/atom/highlights/commit/7fa4414))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highlights",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Syntax highlighter",
   "main": "lib/highlights.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "grunt test",
     "prepublish": "grunt prepublish",
-    "pretest": "git submodule update --init --recursive"
+    "pretest": "git submodule update --init --recursive",
+    "version": "standard-version"
   },
   "bin": "bin/highlights",
   "repository": {
@@ -23,17 +24,18 @@
     "first-mate-select-grammar": "^1.0.1",
     "fs-plus": "^2.2.6",
     "once": "^1.3.2",
-    "optimist": "^0.6.1",
     "season": "^5.1.2",
-    "underscore-plus": "^1.5.1"
+    "underscore-plus": "^1.5.1",
+    "yargs": "^4.7.1"
   },
   "devDependencies": {
-    "grunt": "^0.4.4",
-    "grunt-cli": "^0.1.13",
-    "grunt-coffeelint": "0.0.8",
-    "grunt-contrib-coffee": "^0.10.1",
-    "grunt-shell": "^0.6.4",
+    "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
+    "grunt-coffeelint": "0.0.16",
+    "grunt-contrib-coffee": "^1.0.0",
+    "grunt-shell": "^1.3.0",
     "jasmine-focused": "^1.0.4",
-    "language-erlang": "^2.0.0"
+    "language-erlang": "^2.0.0",
+    "standard-version": "^2.3.1"
   }
 }

--- a/spec/highlights-spec.coffee
+++ b/spec/highlights-spec.coffee
@@ -59,7 +59,7 @@ describe "Highlights", ->
     it "includes the grammar when the path is a file", (done) ->
       highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes'))
       highlights.highlight(fileContents: 'test', scopeName: 'include1', (err, html) ->
-        expect(!err).toBe true
+        expect(not err).toBe true
         expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="include1"><span>test</span></span></div></pre>'
         done()
       )
@@ -67,14 +67,14 @@ describe "Highlights", ->
     it "includes the grammars when the path is a directory", (done) ->
       highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes', 'include1.cson'))
       highlights.highlight fileContents: 'test', scopeName: 'include1', (err, html) ->
-        expect(!err).toBe true
+        expect(not err).toBe true
         expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="include1"><span>test</span></span></div></pre>'
         done()
 
     it "overrides built-in grammars", (done) ->
       highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes'))
-      highlights.highlight(fileContents: 's = "test"', scopeName: 'source.coffee',(err, html) ->
-        expect(!err).toBe true
+      highlights.highlight(fileContents: 's = "test"', scopeName: 'source.coffee', (err, html) ->
+        expect(not err).toBe true
         expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="source coffee"><span>s&nbsp;=&nbsp;&quot;test&quot;</span></span></div></pre>'
         done()
       )
@@ -83,14 +83,14 @@ describe "Highlights", ->
     it "calls back an HTML string", (done) ->
       highlights = new Highlights()
       highlights.highlight fileContents: 'test', (err, html) ->
-        expect(!err).toBe true
+        expect(not err).toBe true
         expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="text plain null-grammar"><span>test</span></span></div></pre>'
         done()
 
     it "uses the given scope name as the grammar to tokenize with", (done) ->
       highlights = new Highlights()
       highlights.highlight fileContents: 'test', scopeName: 'source.coffee', (err, html) ->
-        expect(!err).toBe true
+        expect(not err).toBe true
         expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="source coffee"><span>test</span></span></div></pre>'
         done()
 
@@ -103,22 +103,22 @@ describe "Highlights", ->
   describe "async: requireGrammars", ->
     it "loads the grammars async from a file-based npm module path", (done) ->
       highlights = new Highlights()
-      highlights.requireGrammars modulePath: require.resolve('language-erlang/package.json'),(err) ->
-        expect(!err).toBe true
+      highlights.requireGrammars modulePath: require.resolve('language-erlang/package.json'), (err) ->
+        expect(not err).toBe true
         expect(highlights.registry.grammarForScopeName('source.erlang')?.path).toBe path.resolve(__dirname, '..', 'node_modules', 'language-erlang', 'grammars', 'erlang.cson')
         done()
 
     it "loads the grammars from a folder-based npm module path", (done) ->
       highlights = new Highlights()
-      highlights.requireGrammars modulePath: path.resolve(__dirname, '..', 'node_modules', 'language-erlang'),(err) ->
-        expect(!err).toBe true
+      highlights.requireGrammars modulePath: path.resolve(__dirname, '..', 'node_modules', 'language-erlang'), (err) ->
+        expect(not err).toBe true
         expect(highlights.registry.grammarForScopeName('source.erlang')?.path).toBe path.resolve(__dirname, '..', 'node_modules', 'language-erlang', 'grammars', 'erlang.cson')
         done()
 
     it "loads default grammars prior to loading grammar from module", (done) ->
       highlights = new Highlights()
       highlights.requireGrammars modulePath: require.resolve('language-erlang/package.json'), (err, html) ->
-        highlights.highlight fileContents: 'test', scopeName: 'source.coffee', (err,html) ->
-          expect(!err).toBe true
+        highlights.highlight fileContents: 'test', scopeName: 'source.coffee', (err, html) ->
+          expect(not err).toBe true
           expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="source coffee"><span>test</span></span></div></pre>'
           done()

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -1,37 +1,29 @@
 path = require 'path'
 fs = require 'fs-plus'
-optimist = require 'optimist'
+yargs = require 'yargs'
 Highlights = require './highlights'
 
 module.exports = ->
-  cli = optimist.describe('h', 'Show this message').alias('h', 'help')
-                .describe('i', 'Path to file or folder of grammars to include').alias('i', 'include').string('i')
-                .describe('o', 'File path to write the HTML output to').alias('o', 'output').string('o')
-                .describe('s', 'Scope name of the grammar to use').alias('s', 'scope').string('s')
-                .describe('v', 'Output the version').alias('v', 'version').boolean('v')
-                .describe('f', 'File path to use for grammar detection when reading from stdin').alias('f', 'file-path').string('f')
-  optimist.usage """
-    Usage: highlights [options] [file]
+  argv = yargs.describe('i', 'Path to file or folder of grammars to include').alias('i', 'include').string('i')
+    .describe('o', 'File path to write the HTML output to').alias('o', 'output').string('o')
+    .describe('s', 'Scope name of the grammar to use').alias('s', 'scope').string('s')
+    .describe('f', 'File path to use for grammar detection when reading from stdin').alias('f', 'file-path').string('f')
+    .help('h').alias('h', 'help')
+    .usage """
+     Usage: highlights [options] [file]
 
-    Output the syntax highlighted HTML for a file.
+     Output the syntax highlighted HTML for a file.
 
-    If no input file is specified then the text to highlight is read from standard in.
+     If no input file is specified then the text to highlight is read from standard in.
 
-    If no output file is specified then the HTML is written to standard out.
-  """
+     If no output file is specified then the HTML is written to standard out.
+    """
+    .version().alias('v', 'version')
+    .argv
 
-  if cli.argv.help
-    cli.showHelp()
-    return
+  [filePath] = argv._
 
-  if cli.argv.version
-    {version} = require '../package.json'
-    console.log(version)
-    return
-
-  [filePath] = cli.argv._
-
-  outputPath = cli.argv.output
+  outputPath = argv.output
   outputPath = path.resolve(outputPath) if outputPath
 
   if filePath
@@ -41,19 +33,19 @@ module.exports = ->
       process.exit(1)
       return
 
-    html = new Highlights().highlightSync({filePath, scopeName: cli.argv.scope})
+    html = new Highlights().highlightSync({filePath, scopeName: argv.scope})
     if outputPath
       fs.writeFileSync(outputPath, html)
     else
       console.log(html)
   else
-    filePath = cli.argv.f
+    filePath = argv.f
     process.stdin.resume()
     process.stdin.setEncoding('utf8')
     fileContents = ''
     process.stdin.on 'data', (chunk) -> fileContents += chunk.toString()
     process.stdin.on 'end', ->
-      html = new Highlights().highlightSync({filePath, fileContents, scopeName: cli.argv.scope})
+      html = new Highlights().highlightSync({filePath, fileContents, scopeName: argv.scope})
       if outputPath
         fs.writeFileSync(outputPath, html)
       else

--- a/src/highlights.coffee
+++ b/src/highlights.coffee
@@ -53,18 +53,18 @@ class Highlights
   # Calls back with a string of HTML. The HTML will contains one <pre> with one <div>
   # per line and each line will contain one or more <span> elements for the
   # tokens in the line. All grammar loading and fs operations are async so you can use this module in a server or busy process.
-  highlight: ({filePath, fileContents, scopeName}={},cb) ->
+  highlight: ({filePath, fileContents, scopeName}={}, cb) ->
 
 
     @loadGrammars (err) =>
       return cb(err) if err
 
-      if filePath and !fileContents
-        fs.readFile filePath, 'utf8', (err,fileContents) =>
+      if filePath and not fileContents
+        fs.readFile filePath, 'utf8', (err, fileContents) =>
           return cb(err) if err
-          cb(false,@_highlightCommon({filePath, fileContents, scopeName}))
+          cb(false, @_highlightCommon({filePath, fileContents, scopeName}))
       else
-        cb(false,@_highlightCommon({filePath, fileContents, scopeName}))
+        cb(false, @_highlightCommon({filePath, fileContents, scopeName}))
 
   # Public: Require all the grammars from the grammars folder at the root of an
   #   npm module.
@@ -98,7 +98,7 @@ class Highlights
   #              directory will be used.
   # cb(err) - The callback so you know when it's done
   #
-  requireGrammars: ({modulePath}={},cb) ->
+  requireGrammars: ({modulePath}={}, cb) ->
     @loadGrammars (err) =>
       return cb(err) if err
 
@@ -114,9 +114,9 @@ class Highlights
           return cb()
 
         grammarsDir = path.resolve(packageDir, 'grammars')
-        @_registryLoadGrammarsDir(grammarsDir,cb)
+        @_registryLoadGrammarsDir(grammarsDir, cb)
 
-  _registryLoadGrammarsDir: (dir,cb) ->
+  _registryLoadGrammarsDir: (dir, cb) ->
     cb = once(cb)
     todo = false
     done = (err) ->
@@ -128,7 +128,7 @@ class Highlights
         return cb(err)
 
       todo = files.length
-      return cb(false,[]) unless todo
+      return cb(false, []) unless todo
 
       while files.length
         file = files.shift()
@@ -137,14 +137,14 @@ class Highlights
         if CSON.isObjectPath(grammarPath)
           @_registryLoadGrammar grammarPath, (err) -> done(err)
 
-  _registryLoadGrammar: (grammarPath,cb) ->
-    fs.stat grammarPath,(err,stat) =>
+  _registryLoadGrammar: (grammarPath, cb) ->
+    fs.stat grammarPath, (err, stat) =>
       return cb(err) if err
 
       # does not error out at this stage if the file is named like a grammar but is not a file.
-      return cb() if !stat.isFile()
+      return cb() if not stat.isFile()
 
-      @registry.loadGrammar(grammarPath,cb)
+      @registry.loadGrammar(grammarPath, cb)
 
   _highlightCommon: ({filePath, fileContents, scopeName}={}) ->
 
@@ -194,7 +194,7 @@ class Highlights
   loadGrammars: (cb) ->
     cb = once(cb)
 
-    if @_loadingGrammars == true or @registry.grammars.length > 1
+    if @_loadingGrammars is true or @registry.grammars.length > 1
       return setImmediate(cb)
     else if Array.isArray(@_loadingGrammars)
       return @_loadingGrammars.push(cb)
@@ -211,52 +211,52 @@ class Highlights
     grammarsFromJSON = null
     grammarsArray = null
 
-    done = (err,paths) =>
+    done = (err, paths) =>
       return callbacks(err) if err
-      if !--pendingAsyncCalls
+      if not --pendingAsyncCalls
         @_populateGrammars(grammarsFromJSON, grammarsArray, callbacks)
 
-    @_findGrammars (err,arr) ->
+    @_findGrammars (err, arr) ->
       grammarsArray = arr
       done(err)
 
-    @_loadGrammarsJSON (err,fromJSON) ->
+    @_loadGrammarsJSON (err, fromJSON) ->
       grammarsFromJSON = fromJSON
       done(err)
 
-  _populateGrammars: (grammarsFromJSON,grammarsArray,cb) ->
-    toLoad = (grammarsArray||[]).length
+  _populateGrammars: (grammarsFromJSON, grammarsArray, cb) ->
+    toLoad = (grammarsArray or []).length
     grammars = []
 
-    done = (err,grammar) =>
+    done = (err, grammar) =>
       return cb(err) if err
 
       grammars.push(grammar) if grammar
 
-      if !--toLoad
+      if not --toLoad
         # complete loading from grammars.json
         for grammarPath, grammar of grammarsFromJSON
           continue if @registry.grammarForScopeName(grammar.scopeName)?
           grammar = @registry.createGrammar(grammarPath, grammar)
           @registry.addGrammar(grammar)
 
-        cb(false,true)
+        cb(false, true)
 
-    if !toLoad
+    if not toLoad
       toLoad = 1
       return done()
 
     while grammarsArray.length
-      @registry.loadGrammar(grammarsArray.shift(),done)
+      @registry.loadGrammar(grammarsArray.shift(), done)
 
   _findGrammars: (cb) ->
     if typeof @includePath is 'string'
       fs.stat @includePath, (err, stat) =>
         return cb(err) if err
         if stat.isFile()
-          cb(false,[@includePath])
+          cb(false, [@includePath])
         else if stat.isDirectory()
-          fs.list @includePath,['cson','json'], (err,list=[]) -> cb(err,list)
+          fs.list @includePath, ['cson', 'json'], (err, list=[]) -> cb(err, list)
         else
           cb(new Error('unsupported file type.'))
     else
@@ -264,7 +264,7 @@ class Highlights
 
   _loadGrammarsJSON: (cb) ->
     grammarsPath = path.join(__dirname, '..', 'gen', 'grammars.json')
-    fs.readFile grammarsPath, (err,contents) ->
+    fs.readFile grammarsPath, (err, contents) ->
       try
         cb(false, JSON.parse(contents))
       catch err


### PR DESCRIPTION
## notes

* updating the coffee-script linter required a few stylistic nits, if folks could make sure I didn't typo anything.
* I switched us from optimist to yargs (which meant I could remove a few lines of code).
* I added standard-version, which I can use shortly to manage our semver bumps and CHANGELOG generation, see: https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md