### PR TITLE
Adopt the new `syntax--` convention when transforming scopes into class names

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -36,6 +36,6 @@ module.exports = (grunt) ->
     grunt.file.delete('gen') if grunt.file.exists('gen')
 
   grunt.registerTask('lint', ['coffeelint'])
-  grunt.registerTask('default', ['coffeelint', 'coffee'])
+  grunt.registerTask('default', ['coffeelint', 'coffee', 'build-grammars'])
   grunt.registerTask('test', ['default', 'lint', 'shell:test'])
   grunt.registerTask('prepublish', ['clean', 'build-grammars', 'test'])

--- a/spec/highlights-spec.coffee
+++ b/spec/highlights-spec.coffee
@@ -6,33 +6,33 @@ describe "Highlights", ->
     it "includes the grammar when the path is a file", ->
       highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes'))
       html = highlights.highlightSync(fileContents: 'test', scopeName: 'include1')
-      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="include1"><span>test</span></span></div></pre>'
+      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--include1"><span>test</span></span></div></pre>'
 
     it "includes the grammars when the path is a directory", ->
       highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes', 'include1.cson'))
       html = highlights.highlightSync(fileContents: 'test', scopeName: 'include1')
-      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="include1"><span>test</span></span></div></pre>'
+      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--include1"><span>test</span></span></div></pre>'
 
     it "overrides built-in grammars", ->
       highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes'))
       html = highlights.highlightSync(fileContents: 's = "test"', scopeName: 'source.coffee')
-      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="source coffee"><span>s&nbsp;=&nbsp;&quot;test&quot;</span></span></div></pre>'
+      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>s&nbsp;=&nbsp;&quot;test&quot;</span></span></div></pre>'
 
   describe "highlightSync", ->
     it "returns an HTML string", ->
       highlights = new Highlights()
       html = highlights.highlightSync(fileContents: 'test')
-      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="text plain null-grammar"><span>test</span></span></div></pre>'
+      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--text syntax--plain syntax--null-grammar"><span>test</span></span></div></pre>'
 
     it "uses the given scope name as the grammar to tokenize with", ->
       highlights = new Highlights()
       html = highlights.highlightSync(fileContents: 'test', scopeName: 'source.coffee')
-      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="source coffee"><span>test</span></span></div></pre>'
+      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>test</span></span></div></pre>'
 
     it "uses the best grammar match when no scope name is specified", ->
       highlights = new Highlights()
       html = highlights.highlightSync(fileContents: 'test', filePath: 'test.coffee')
-      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="source coffee"><span>test</span></span></div></pre>'
+      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>test</span></span></div></pre>'
 
   describe "requireGrammarsSync", ->
     it "loads the grammars from a file-based npm module path", ->
@@ -49,7 +49,7 @@ describe "Highlights", ->
       highlights = new Highlights()
       highlights.requireGrammarsSync(modulePath: require.resolve('language-erlang/package.json'))
       html = highlights.highlightSync(fileContents: 'test', scopeName: 'source.coffee')
-      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="source coffee"><span>test</span></span></div></pre>'
+      expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>test</span></span></div></pre>'
 
   #
   # async tests
@@ -60,7 +60,7 @@ describe "Highlights", ->
       highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes'))
       highlights.highlight(fileContents: 'test', scopeName: 'include1', (err, html) ->
         expect(not err).toBe true
-        expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="include1"><span>test</span></span></div></pre>'
+        expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--include1"><span>test</span></span></div></pre>'
         done()
       )
 
@@ -68,14 +68,14 @@ describe "Highlights", ->
       highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes', 'include1.cson'))
       highlights.highlight fileContents: 'test', scopeName: 'include1', (err, html) ->
         expect(not err).toBe true
-        expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="include1"><span>test</span></span></div></pre>'
+        expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--include1"><span>test</span></span></div></pre>'
         done()
 
     it "overrides built-in grammars", (done) ->
       highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes'))
       highlights.highlight(fileContents: 's = "test"', scopeName: 'source.coffee', (err, html) ->
         expect(not err).toBe true
-        expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="source coffee"><span>s&nbsp;=&nbsp;&quot;test&quot;</span></span></div></pre>'
+        expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>s&nbsp;=&nbsp;&quot;test&quot;</span></span></div></pre>'
         done()
       )
 
@@ -84,20 +84,20 @@ describe "Highlights", ->
       highlights = new Highlights()
       highlights.highlight fileContents: 'test', (err, html) ->
         expect(not err).toBe true
-        expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="text plain null-grammar"><span>test</span></span></div></pre>'
+        expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--text syntax--plain syntax--null-grammar"><span>test</span></span></div></pre>'
         done()
 
     it "uses the given scope name as the grammar to tokenize with", (done) ->
       highlights = new Highlights()
       highlights.highlight fileContents: 'test', scopeName: 'source.coffee', (err, html) ->
         expect(not err).toBe true
-        expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="source coffee"><span>test</span></span></div></pre>'
+        expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>test</span></span></div></pre>'
         done()
 
     it "uses the best grammar match when no scope name is specified", (done) ->
       highlights = new Highlights()
       highlights.highlight fileContents: 'test', filePath: 'test.coffee', (err, html) ->
-        expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="source coffee"><span>test</span></span></div></pre>'
+        expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>test</span></span></div></pre>'
         done()
 
   describe "async: requireGrammars", ->
@@ -120,5 +120,5 @@ describe "Highlights", ->
       highlights.requireGrammars modulePath: require.resolve('language-erlang/package.json'), (err, html) ->
         highlights.highlight fileContents: 'test', scopeName: 'source.coffee', (err, html) ->
           expect(not err).toBe true
-          expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="source coffee"><span>test</span></span></div></pre>'
+          expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>test</span></span></div></pre>'
           done()

--- a/src/highlights.coffee
+++ b/src/highlights.coffee
@@ -299,7 +299,10 @@ class Highlights
 
   pushScope: (scopeStack, scope, html) ->
     scopeStack.push(scope)
-    html += "<span class=\"#{scope.replace(/\.+/g, ' ')}\">"
+    if scope
+      html += "<span class=\"syntax--#{scope.replace(/\.+/g, ' syntax--')}\">"
+    else
+      html += "<span>"
 
   popScope: (scopeStack, html) ->
     scopeStack.pop()


### PR DESCRIPTION
After transitioning away from the shadow DOM in `<atom-text-editor>` elements, we accidentally forgot to update this repository to prepend `syntax--` when transforming scopes into CSS class names. This resulted in an inconsistency between the CSS files we use in Atom and the HTML that gets generated from this library, thus causing regressions like https://github.com/atom/markdown-preview/issues/461.

This pull request changes it so that the emitted HTML complies to the new `syntax--` convention. Considering this is a breaking change, I am planning to merge this pull request and bump the major version to ensure other users of this library don't observe regressions.

/cc: @atom/core 