### PR TITLE
Allow users to provide a scope prefix for class names

### DIFF
--- a/spec/highlights-spec.coffee
+++ b/spec/highlights-spec.coffee
@@ -4,49 +4,49 @@ Highlights = require '../src/highlights'
 describe "Highlights", ->
   describe "when an includePath is specified", ->
     it "includes the grammar when the path is a file", ->
-      highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes'))
+      highlights = new Highlights(scopePrefix: 'syntax--', includePath: path.join(__dirname, 'fixtures', 'includes'))
       html = highlights.highlightSync(fileContents: 'test', scopeName: 'include1')
       expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--include1"><span>test</span></span></div></pre>'
 
     it "includes the grammars when the path is a directory", ->
-      highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes', 'include1.cson'))
+      highlights = new Highlights(scopePrefix: 'syntax--', includePath: path.join(__dirname, 'fixtures', 'includes', 'include1.cson'))
       html = highlights.highlightSync(fileContents: 'test', scopeName: 'include1')
       expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--include1"><span>test</span></span></div></pre>'
 
     it "overrides built-in grammars", ->
-      highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes'))
+      highlights = new Highlights(scopePrefix: 'syntax--', includePath: path.join(__dirname, 'fixtures', 'includes'))
       html = highlights.highlightSync(fileContents: 's = "test"', scopeName: 'source.coffee')
       expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>s&nbsp;=&nbsp;&quot;test&quot;</span></span></div></pre>'
 
   describe "highlightSync", ->
     it "returns an HTML string", ->
-      highlights = new Highlights()
+      highlights = new Highlights(scopePrefix: 'syntax--')
       html = highlights.highlightSync(fileContents: 'test')
       expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--text syntax--plain syntax--null-grammar"><span>test</span></span></div></pre>'
 
     it "uses the given scope name as the grammar to tokenize with", ->
-      highlights = new Highlights()
+      highlights = new Highlights(scopePrefix: 'syntax--')
       html = highlights.highlightSync(fileContents: 'test', scopeName: 'source.coffee')
       expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>test</span></span></div></pre>'
 
     it "uses the best grammar match when no scope name is specified", ->
-      highlights = new Highlights()
+      highlights = new Highlights(scopePrefix: 'syntax--')
       html = highlights.highlightSync(fileContents: 'test', filePath: 'test.coffee')
       expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>test</span></span></div></pre>'
 
   describe "requireGrammarsSync", ->
     it "loads the grammars from a file-based npm module path", ->
-      highlights = new Highlights()
+      highlights = new Highlights(scopePrefix: 'syntax--')
       highlights.requireGrammarsSync(modulePath: require.resolve('language-erlang/package.json'))
       expect(highlights.registry.grammarForScopeName('source.erlang').path).toBe path.resolve(__dirname, '..', 'node_modules', 'language-erlang', 'grammars', 'erlang.cson')
 
     it "loads the grammars from a folder-based npm module path", ->
-      highlights = new Highlights()
+      highlights = new Highlights(scopePrefix: 'syntax--')
       highlights.requireGrammarsSync(modulePath: path.resolve(__dirname, '..', 'node_modules', 'language-erlang'))
       expect(highlights.registry.grammarForScopeName('source.erlang').path).toBe path.resolve(__dirname, '..', 'node_modules', 'language-erlang', 'grammars', 'erlang.cson')
 
     it "loads default grammars prior to loading grammar from module", ->
-      highlights = new Highlights()
+      highlights = new Highlights(scopePrefix: 'syntax--')
       highlights.requireGrammarsSync(modulePath: require.resolve('language-erlang/package.json'))
       html = highlights.highlightSync(fileContents: 'test', scopeName: 'source.coffee')
       expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>test</span></span></div></pre>'
@@ -57,7 +57,7 @@ describe "Highlights", ->
 
   describe "async: when an includePath is specified", ->
     it "includes the grammar when the path is a file", (done) ->
-      highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes'))
+      highlights = new Highlights(scopePrefix: 'syntax--', includePath: path.join(__dirname, 'fixtures', 'includes'))
       highlights.highlight(fileContents: 'test', scopeName: 'include1', (err, html) ->
         expect(not err).toBe true
         expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--include1"><span>test</span></span></div></pre>'
@@ -65,14 +65,14 @@ describe "Highlights", ->
       )
 
     it "includes the grammars when the path is a directory", (done) ->
-      highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes', 'include1.cson'))
+      highlights = new Highlights(scopePrefix: 'syntax--', includePath: path.join(__dirname, 'fixtures', 'includes', 'include1.cson'))
       highlights.highlight fileContents: 'test', scopeName: 'include1', (err, html) ->
         expect(not err).toBe true
         expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--include1"><span>test</span></span></div></pre>'
         done()
 
     it "overrides built-in grammars", (done) ->
-      highlights = new Highlights(includePath: path.join(__dirname, 'fixtures', 'includes'))
+      highlights = new Highlights(scopePrefix: 'syntax--', includePath: path.join(__dirname, 'fixtures', 'includes'))
       highlights.highlight(fileContents: 's = "test"', scopeName: 'source.coffee', (err, html) ->
         expect(not err).toBe true
         expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>s&nbsp;=&nbsp;&quot;test&quot;</span></span></div></pre>'
@@ -81,42 +81,42 @@ describe "Highlights", ->
 
   describe "async: highlight", ->
     it "calls back an HTML string", (done) ->
-      highlights = new Highlights()
+      highlights = new Highlights(scopePrefix: 'syntax--')
       highlights.highlight fileContents: 'test', (err, html) ->
         expect(not err).toBe true
         expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--text syntax--plain syntax--null-grammar"><span>test</span></span></div></pre>'
         done()
 
     it "uses the given scope name as the grammar to tokenize with", (done) ->
-      highlights = new Highlights()
+      highlights = new Highlights(scopePrefix: 'syntax--')
       highlights.highlight fileContents: 'test', scopeName: 'source.coffee', (err, html) ->
         expect(not err).toBe true
         expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>test</span></span></div></pre>'
         done()
 
     it "uses the best grammar match when no scope name is specified", (done) ->
-      highlights = new Highlights()
+      highlights = new Highlights(scopePrefix: 'syntax--')
       highlights.highlight fileContents: 'test', filePath: 'test.coffee', (err, html) ->
         expect(html).toBe '<pre class="editor editor-colors"><div class="line"><span class="syntax--source syntax--coffee"><span>test</span></span></div></pre>'
         done()
 
   describe "async: requireGrammars", ->
     it "loads the grammars async from a file-based npm module path", (done) ->
-      highlights = new Highlights()
+      highlights = new Highlights(scopePrefix: 'syntax--')
       highlights.requireGrammars modulePath: require.resolve('language-erlang/package.json'), (err) ->
         expect(not err).toBe true
         expect(highlights.registry.grammarForScopeName('source.erlang')?.path).toBe path.resolve(__dirname, '..', 'node_modules', 'language-erlang', 'grammars', 'erlang.cson')
         done()
 
     it "loads the grammars from a folder-based npm module path", (done) ->
-      highlights = new Highlights()
+      highlights = new Highlights(scopePrefix: 'syntax--')
       highlights.requireGrammars modulePath: path.resolve(__dirname, '..', 'node_modules', 'language-erlang'), (err) ->
         expect(not err).toBe true
         expect(highlights.registry.grammarForScopeName('source.erlang')?.path).toBe path.resolve(__dirname, '..', 'node_modules', 'language-erlang', 'grammars', 'erlang.cson')
         done()
 
     it "loads default grammars prior to loading grammar from module", (done) ->
-      highlights = new Highlights()
+      highlights = new Highlights(scopePrefix: 'syntax--')
       highlights.requireGrammars modulePath: require.resolve('language-erlang/package.json'), (err, html) ->
         highlights.highlight fileContents: 'test', scopeName: 'source.coffee', (err, html) ->
           expect(not err).toBe true

--- a/src/highlights.coffee
+++ b/src/highlights.coffee
@@ -16,9 +16,10 @@ class Highlights
   #   :includePath - An optional String path to a file or folder of grammars to
   #                  register.
   #   :registry    - An optional GrammarRegistry instance.
-  constructor: ({@includePath, @registry}={}) ->
+  constructor: ({@includePath, @registry, @scopePrefix}={}) ->
     @registry ?= new GrammarRegistry(maxTokensPerLine: Infinity)
     @_loadingGrammars = false
+    @scopePrefix ?= ''
 
   # Public: Syntax highlight the given file synchronously.
   #
@@ -300,7 +301,8 @@ class Highlights
   pushScope: (scopeStack, scope, html) ->
     scopeStack.push(scope)
     if scope
-      html += "<span class=\"syntax--#{scope.replace(/\.+/g, ' syntax--')}\">"
+      className = @scopePrefix + scope.replace(/\.+/g, " #{@scopePrefix}")
+      html += "<span class=\"#{className}\">"
     else
       html += "<span>"
 


### PR DESCRIPTION
Refs: #49.

When not provided, `scopePrefix` will default to an empty string. In the case of Atom we will need to supply `syntax--` in order to match the new style convention. Even though this change is backwards compatible with 1.5.0, I am unable to unpublish the previous major version bump, so as soon as this pull request becomes green I will bump the package to version 2.1.0.

/cc: @nathansobo @bcoe 