### PR TITLE
fix: hold fs-plus at 2.9.3 for node 4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "first-mate": "^6.0.0",
     "first-mate-select-grammar": "^1.0.1",
-    "fs-plus": "^2.2.6",
+    "fs-plus": "~2.9.3",
     "once": "^1.3.2",
     "season": "^5.1.2",
     "underscore-plus": "^1.5.1",


### PR DESCRIPTION
see issue: https://github.com/atom/fs-plus/issues/38

2.10.0 of fs-plus breaks on Node 4 because it uses Proxy and Proxy is not defined