### PR TITLE
Add support for highlighting TypeScript

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -88,3 +88,6 @@
 [submodule "deps/language-react"]
 	path = deps/language-react
 	url = https://github.com/orktes/atom-react.git
+[submodule "deps/language-typescript"]
+	path = deps/language-typescript
+	url = https://github.com/TypeStrong/atom-typescript.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -85,3 +85,6 @@
 [submodule "deps/language-clojure"]
 	path = deps/language-clojure
 	url = https://github.com/atom/language-clojure
+[submodule "deps/language-react"]
+	path = deps/language-react
+	url = https://github.com/orktes/atom-react.git


### PR DESCRIPTION
Got a [request](https://github.com/npm/marky-markdown/issues/397) in marky-markdown (and there's also #53 here) for adding TypeScript, so that led me to discover [atom-typescript](https://atom.io/packages/atom-typescript) which happens to be structured such that we can pull it in as a submodule and `highlights` can learn TypeScript from it.

Similar to #55, the package isn't in the atom org, so if that's an issue, so be it. The code is MIT licensed, FWIW.