### PR TITLE
Revert "Fix #64"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/atom/highlights",
   "dependencies": {
     "first-mate": "^7.0.2",
-    "first-mate-select-grammar": "https://github.com/atom/first-mate-select-grammar#b7d54921d849e6108f968581bf31e41929fd992f",
+    "first-mate-select-grammar": "^1.0.1",
     "fs-plus": "^3.0.0",
     "once": "^1.3.2",
     "season": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/atom/highlights",
   "dependencies": {
     "first-mate": "^7.0.2",
-    "first-mate-select-grammar": "^1.0.1",
+    "first-mate-select-grammar": "^1.0.3",
     "fs-plus": "^3.0.0",
     "once": "^1.3.2",
     "season": "^6.0.2",


### PR DESCRIPTION
This reverts commit 80ee1a27c4e8568ea2adfe18049fc9610a22d585: a new version of `first-mate-select-grammar` [has been published](https://github.com/soldair/first-mate-select-grammar/pull/2#issuecomment-506039026) so we don't need to depend on a specific commit.

Moreover, that specific commit does not exist anymore, so currently doing `npm install highlights` results in an error, which this PR should fix.